### PR TITLE
Add explicit and peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,11 @@
     "test:coverage": "nwb test-react --coverage",
     "test:watch": "nwb test-react --server"
   },
-  "dependencies": {},
+  "dependencies": {
+    "ajv": "^6.x",
+    "inferno": "^3.x",
+    "prop-types": "^15.6.2"
+  },
   "peerDependencies": {
     "react": "16.x"
   },


### PR DESCRIPTION
`prop-types` is required by index.js, but not specified in the package.json. While the module itself still works, this causes certain analysis tools to fail, such as [bundlephobia](https://bundlephobia.com/result?p=react-sticky-footer), a tool to determine the cost of adding a package to your bundle.


`npm install` was also complaining that ajv and inferno were required as peer dependencies, so I added appropriate versions of those, too.
![image](https://user-images.githubusercontent.com/34654094/44060239-08bbc8ae-9f22-11e8-8f3d-9758b20139d0.png)


I was unable to verify if the tests still pass, as I could not get them working off of a clean master. The demo server still looks great, however.